### PR TITLE
Restore Data nodes from under the dslink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # ChangeLog
 
+## 2.0.3
+
+### Bug Fixes
+
+* Restore `data` node under the root of the link. This replaces the broker's data node with one that will keep the
+data with the DSLink configuration rather than at broker level. 
+
 ## 2.0.2
 
 ### Features

--- a/bin/run.dart
+++ b/bin/run.dart
@@ -35,8 +35,20 @@ Future<Null> main(List<String> args) async {
   defaultNodes: {
     AddSchedule.pathName: AddSchedule.def(),
     ImportSchedule.pathName: ImportSchedule.def(),
+    DataRootNode.pathName: DataRootNode.def()
   }, autoInitialize: false);
 
   link.init();
+
+  _addMissing(link, "/${DataRootNode.pathName}", DataRootNode.def());
+
   link.connect();
+}
+
+void _addMissing(LinkProvider link, String path, Map<String, dynamic> map) {
+  var provider = link.provider as SimpleNodeProvider;
+  var nd = provider.getNode(path);
+  if (nd == null) {
+    link.addNode(path, map);
+  }
 }

--- a/dslink.json
+++ b/dslink.json
@@ -1,6 +1,6 @@
 {
   "name": "dslink-dart-localschedule",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Schedule DSLink",
   "main": "bin/run.dart",
   "engines": {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dslink_localschedule
-version: 2.0.2
+version: 2.0.3
 description: Schedule DSLink
 dependencies:
   dslink:


### PR DESCRIPTION
Data nodes were implemented in 0.1.x on the schedule link.
They still exist but were not being added to the tree. Re-added them.